### PR TITLE
chore: update deps and adopt workspace dependency inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,9 +486,9 @@ version = "0.1.0"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -501,9 +501,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -573,22 +573,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -696,22 +696,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,41 @@
 [workspace]
 resolver = "3"
-
 members = ["crates/*"]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2024"
+
+[workspace.dependencies]
+# Internal crates
+color = { path = "crates/color" }
+msi = { path = "crates/msi", default-features = false }
+msi_installer = { path = "crates/msi_installer" }
+printer = { path = "crates/printer" }
+test_macros = { path = "crates/test_macros" }
+
+# External crates
+ar = "0.9.0"
+bitflags = "2.13.1"
+byteorder = "1"
+cab = "0.6.0"
+cfb = "0.14"
+clap = { version = "4.6.2", features = ["derive"] }
+encoding_rs = "0.8"
+flate2 = "1.1.9"
+indoc = "2.0.7"
+quick-error = "2.0.1"
+quote = "1.0.47"
+strum = "0.28"
+strum_macros = "0.28"
+syn = { version = "3.0.0", features = ["full"] }
+tar = "0.4.46"
+thiserror = "2.0.19"
+time = "0.3.53"
+uuid = "1.24.0"
+which = "8.0.5"
+
+# Dev dependencies
+assertables = "10.1.0"
+insta = "1.48.0"
+pretty_assertions = "1.4.1"

--- a/crates/color/Cargo.toml
+++ b/crates/color/Cargo.toml
@@ -1,7 +1,5 @@
 [package]
 name = "color"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
-
-[dependencies]

--- a/crates/livraison/Cargo.toml
+++ b/crates/livraison/Cargo.toml
@@ -1,34 +1,28 @@
 [package]
 name = "livraison"
-version = "0.1.0"
-edition = "2024"
-
-[lib]
-name = "livraison"
-path = "src/lib.rs"
-doc = true
+version.workspace = true
+edition.workspace = true
 
 [[bin]]
 name = "livraison"
-path = "src/main.rs"
 doc = false
 
 [dependencies]
-ar = "0.9.0"
-cab = "0.6.0"
-clap = { version = "4.6.2", features = ["derive"] }
-msi = { version = "0.8.0", path = "../msi", default-features = false }
-msi_installer = { version = "0.1.0", path = "../msi_installer" }
-printer = { path = "../printer" }
-color = { path = "../color" }
-quick-error = "2.0.1"
-tar = "0.4.46"
-uuid = { version = "1.24.0", features = ["v4", "v5"] }
-indoc = "2.0.7"
-flate2 = "1.1.9"
+ar.workspace = true
+cab.workspace = true
+clap.workspace = true
+color.workspace = true
+flate2.workspace = true
+indoc.workspace = true
+msi.workspace = true
+msi_installer.workspace = true
+printer.workspace = true
+quick-error.workspace = true
+tar.workspace = true
+uuid = { workspace = true, features = ["v4", "v5"] }
 
 [dev-dependencies]
-assertables = "10.1.0"
-pretty_assertions = "1.4.1"
-insta = "1.48.0"
-test_macros = { version = "0.1.0", path = "../test_macros", default-features = false }
+assertables.workspace = true
+insta.workspace = true
+pretty_assertions.workspace = true
+test_macros.workspace = true

--- a/crates/msi/Cargo.toml
+++ b/crates/msi/Cargo.toml
@@ -1,18 +1,16 @@
 [package]
 name = "msi"
 version = "0.8.0"
+edition.workspace = true
 authors = ["Matthew D. Steele <mdsteele@alum.mit.edu>"]
+description = "Read/write Windows Installer (MSI) files"
 repository = "https://github.com/mdsteele/rust-msi"
 keywords = ["msi", "windows", "installer", "package"]
 license = "MIT"
 readme = "README.md"
-edition = "2024"
-description = "Read/write Windows Installer (MSI) files"
 
 [dependencies]
-byteorder = "1"
-cfb = "0.14"
-encoding_rs = "0.8"
-uuid = "1"
-
-[dev-dependencies]
+byteorder.workspace = true
+cfb.workspace = true
+encoding_rs.workspace = true
+uuid.workspace = true

--- a/crates/msi_installer/Cargo.toml
+++ b/crates/msi_installer/Cargo.toml
@@ -1,17 +1,12 @@
 [package]
 name = "msi_installer"
-version = "0.1.0"
-edition = "2024"
-
-[lib]
-name = "msi_installer"
-path = "src/lib.rs"
-doc = true
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
-msi = { version = "0.8.0", path = "../msi", default-features = false }
-thiserror = "2.0.18"
-bitflags = "2.13.1"
-uuid = { version = "1.24.0", features = ["v4", "v5"] }
-strum = "0.28"
-strum_macros = "0.28"
+bitflags.workspace = true
+msi.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
+thiserror.workspace = true
+uuid = { workspace = true, features = ["v4", "v5"] }

--- a/crates/msiinfo/Cargo.toml
+++ b/crates/msiinfo/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "msiinfo"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
-cab = "0.6.0"
-clap = { version = "4.6.2", features = ["derive"] }
-msi = { version = "0.8.0", path = "../msi", default-features = false }
-msi_installer = { version = "0.1.0", path = "../msi_installer" }
-color = { path = "../color" }
-thiserror = "2.0.18"
-time = "0.3.53"
-uuid = { version = "1.24.0", features = ["v4", "v5"] }
+cab.workspace = true
+clap.workspace = true
+color.workspace = true
+msi.workspace = true
+msi_installer.workspace = true
+thiserror.workspace = true
+time.workspace = true
+uuid = { workspace = true, features = ["v4", "v5"] }

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -1,7 +1,5 @@
 [package]
 name = "printer"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 publish = false
-
-[dependencies]

--- a/crates/test_macros/Cargo.toml
+++ b/crates/test_macros/Cargo.toml
@@ -1,15 +1,12 @@
 [package]
 name = "test_macros"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 [lib]
-name = "test_macros"
 proc-macro = true
-path = "src/lib.rs"
-doc = true
 
 [dependencies]
-syn = { version = "3.0.0", features = ["full"] }
-quote = "1.0.44"
-which = "8.0.0"
+quote.workspace = true
+syn.workspace = true
+which.workspace = true


### PR DESCRIPTION
## Summary

Updates dependencies and refactors the Cargo manifests to follow idiomatic workspace conventions.

### Dependency updates
- Applied semver-compatible lockfile bumps: proc-macro2, quote, serde_core, serde_derive, thiserror(-impl).
- Bumped declared floors to match resolved versions where they lagged: `thiserror` 2.0.19, `quote` 1.0.47, `which` 8.0.5.
- Remaining outdated transitive crates (`miniz_oxide` 0.9, `similar` 3.x, `r-efi` 7.0) are hard-blocked by parent constraints (`flate2`, `insta`, `getrandom`) and cannot be bumped yet.

### Manifest cleanup
- Centralized all internal + external + dev dependencies in root `[workspace.dependencies]`; members now use `dep.workspace = true`.
- Added `[workspace.package]` for shared `version` / `edition`; members inherit via `.workspace = true`.
- Feature opt-ins kept at use-site (e.g. `uuid = { workspace = true, features = ["v4", "v5"] }`).
- Removed redundant default-value `[lib]` / `[[bin]]` target sections and empty dependency tables.
- The vendored `msi` crate keeps its own `version = "0.8.0"` and upstream metadata (inherits only `edition`).

### Verification
- `cargo build` clean, no warnings.
- All tests pass.
- `Cargo.lock` changes limited to the 6 version bumps.