### PR TITLE
Add RPM package support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: ./.github/actions/setup
 
       - if: runner.os == 'Linux'
-        run: sudo apt-get install lintian
-        name: Install lintian
+        run: sudo apt-get install lintian rpm
+        name: Install lintian and rpm
 
       - run: pnpm install
         name: Install dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,6 @@ dependencies = [
  "flate2",
  "indoc",
  "insta",
- "md-5",
  "msi",
  "msi_installer",
  "pretty_assertions",
@@ -437,16 +436,6 @@ name = "lzxd"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17f346186eccb574ba5581acefc514f0c70a642db4f96e245034a0a158a7168"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
-]
 
 [[package]]
 name = "memchr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,12 +201,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -211,6 +239,16 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -294,6 +332,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,11 +420,13 @@ dependencies = [
  "flate2",
  "indoc",
  "insta",
+ "md-5",
  "msi",
  "msi_installer",
  "pretty_assertions",
  "printer",
  "quick-error",
+ "sha2",
  "tar",
  "test_macros",
  "uuid",
@@ -387,6 +437,16 @@ name = "lzxd"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17f346186eccb574ba5581acefc514f0c70a642db4f96e245034a0a158a7168"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -598,6 +658,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +833,12 @@ dependencies = [
  "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ clap = { version = "4.6.2", features = ["derive"] }
 encoding_rs = "0.8"
 flate2 = "1.1.9"
 indoc = "2.0.7"
+md-5 = "0.10.6"
+sha2 = "0.10.9"
 quick-error = "2.0.1"
 quote = "1.0.47"
 strum = "0.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ clap = { version = "4.6.2", features = ["derive"] }
 encoding_rs = "0.8"
 flate2 = "1.1.9"
 indoc = "2.0.7"
-md-5 = "0.10.6"
 sha2 = "0.10.9"
 quick-error = "2.0.1"
 quote = "1.0.47"

--- a/crates/livraison/Cargo.toml
+++ b/crates/livraison/Cargo.toml
@@ -14,7 +14,6 @@ clap.workspace = true
 color.workspace = true
 flate2.workspace = true
 indoc.workspace = true
-md-5.workspace = true
 msi.workspace = true
 msi_installer.workspace = true
 printer.workspace = true

--- a/crates/livraison/Cargo.toml
+++ b/crates/livraison/Cargo.toml
@@ -14,10 +14,12 @@ clap.workspace = true
 color.workspace = true
 flate2.workspace = true
 indoc.workspace = true
+md-5.workspace = true
 msi.workspace = true
 msi_installer.workspace = true
 printer.workspace = true
 quick-error.workspace = true
+sha2.workspace = true
 tar.workspace = true
 uuid = { workspace = true, features = ["v4", "v5"] }
 

--- a/crates/livraison/src/actions/pack.rs
+++ b/crates/livraison/src/actions/pack.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::{LivraisonResult, common::FileRef, deb::DebLivraisonPacker, msi::MsiLivraisonPacker};
+use crate::{LivraisonResult, common::FileRef, deb::DebLivraisonPacker, msi::MsiLivraisonPacker, rpm::RpmLivraisonPacker};
 
 #[derive(Debug, Default, Clone)]
 pub struct CommonOptions {
@@ -37,6 +37,7 @@ fn get_packer(target: String) -> Box<dyn LivraisonPacker> {
     match target.as_str() {
         "msi" => Box::new(MsiLivraisonPacker {}),
         "deb" => Box::new(DebLivraisonPacker {}),
+        "rpm" => Box::new(RpmLivraisonPacker {}),
         _ => panic!("Unsupported packer for target: {}", target),
     }
 }

--- a/crates/livraison/src/cli.rs
+++ b/crates/livraison/src/cli.rs
@@ -83,6 +83,7 @@ where
             CommonOptions {
                 name: pack_args.name,
                 version: pack_args.version,
+                description: pack_args.description,
                 bin_files: pack_args
                     .bin_file
                     .iter()

--- a/crates/livraison/src/lib.rs
+++ b/crates/livraison/src/lib.rs
@@ -6,5 +6,6 @@ pub mod common;
 pub mod deb;
 pub mod error;
 pub mod msi;
+pub mod rpm;
 pub mod scripts;
 pub mod utils;

--- a/crates/livraison/src/rpm/constants.rs
+++ b/crates/livraison/src/rpm/constants.rs
@@ -1,0 +1,54 @@
+//! Constants for the RPM binary format.
+//!
+//! Values taken from the RPM file format specification and the `rpm` sources
+//! (`lib/rpmtag.h`).
+
+/// Magic bytes at the start of the lead section.
+pub const RPM_MAGIC: [u8; 4] = [0xed, 0xab, 0xee, 0xdb];
+
+/// Magic bytes at the start of every header structure (signature and main).
+pub const HEADER_MAGIC: [u8; 3] = [0x8e, 0xad, 0xe8];
+
+/// Size in bytes of an index header and of a single index entry.
+pub const INDEX_ENTRY_SIZE: i32 = 16;
+
+/// Region tag marking the boundary of the immutable main header.
+pub const RPMTAG_HEADERIMMUTABLE: u32 = 63;
+
+/// Region tag marking the boundary of the signature header.
+pub const RPMTAG_HEADERSIGNATURES: u32 = 62;
+
+/// Main header tags.
+pub const RPMTAG_NAME: u32 = 1000;
+pub const RPMTAG_VERSION: u32 = 1001;
+pub const RPMTAG_RELEASE: u32 = 1002;
+pub const RPMTAG_SUMMARY: u32 = 1004;
+pub const RPMTAG_DESCRIPTION: u32 = 1005;
+pub const RPMTAG_SIZE: u32 = 1009;
+pub const RPMTAG_LICENSE: u32 = 1014;
+pub const RPMTAG_OS: u32 = 1021;
+pub const RPMTAG_ARCH: u32 = 1022;
+pub const RPMTAG_FILESIZES: u32 = 1028;
+pub const RPMTAG_FILEMODES: u32 = 1030;
+pub const RPMTAG_FILEMTIMES: u32 = 1034;
+pub const RPMTAG_FILEDIGESTS: u32 = 1035;
+pub const RPMTAG_FILEFLAGS: u32 = 1037;
+pub const RPMTAG_FILEUSERNAME: u32 = 1039;
+pub const RPMTAG_FILEGROUPNAME: u32 = 1040;
+pub const RPMTAG_RPMVERSION: u32 = 1064;
+pub const RPMTAG_DIRINDEXES: u32 = 1116;
+pub const RPMTAG_BASENAMES: u32 = 1117;
+pub const RPMTAG_DIRNAMES: u32 = 1118;
+pub const RPMTAG_PAYLOADFORMAT: u32 = 1124;
+pub const RPMTAG_PAYLOADCOMPRESSOR: u32 = 1125;
+pub const RPMTAG_PAYLOADFLAGS: u32 = 1126;
+pub const RPMTAG_FILEDIGESTALGO: u32 = 5011;
+pub const RPMTAG_ENCODING: u32 = 5062;
+
+/// Signature header tags.
+pub const RPMSIGTAG_SIZE: u32 = 1000;
+pub const RPMSIGTAG_MD5: u32 = 1004;
+pub const RPMSIGTAG_SHA256: u32 = 273;
+
+/// File digest algorithm identifier for SHA-256 (`RPMTAG_FILEDIGESTALGO`).
+pub const RPM_DIGEST_ALGO_SHA256: u32 = 8;

--- a/crates/livraison/src/rpm/constants.rs
+++ b/crates/livraison/src/rpm/constants.rs
@@ -44,10 +44,13 @@ pub const RPMTAG_PAYLOADCOMPRESSOR: u32 = 1125;
 pub const RPMTAG_PAYLOADFLAGS: u32 = 1126;
 pub const RPMTAG_FILEDIGESTALGO: u32 = 5011;
 pub const RPMTAG_ENCODING: u32 = 5062;
+/// SHA-256 digest of the (compressed) payload archive, as a hex string array.
+pub const RPMTAG_PAYLOADDIGEST: u32 = 5092;
+/// Digest algorithm identifier for `RPMTAG_PAYLOADDIGEST`.
+pub const RPMTAG_PAYLOADDIGESTALGO: u32 = 5093;
 
 /// Signature header tags.
 pub const RPMSIGTAG_SIZE: u32 = 1000;
-pub const RPMSIGTAG_MD5: u32 = 1004;
 pub const RPMSIGTAG_SHA256: u32 = 273;
 
 /// File digest algorithm identifier for SHA-256 (`RPMTAG_FILEDIGESTALGO`).

--- a/crates/livraison/src/rpm/constants.rs
+++ b/crates/livraison/src/rpm/constants.rs
@@ -26,6 +26,7 @@ pub const RPMTAG_SUMMARY: u32 = 1004;
 pub const RPMTAG_DESCRIPTION: u32 = 1005;
 pub const RPMTAG_SIZE: u32 = 1009;
 pub const RPMTAG_LICENSE: u32 = 1014;
+pub const RPMTAG_PACKAGER: u32 = 1015;
 pub const RPMTAG_OS: u32 = 1021;
 pub const RPMTAG_ARCH: u32 = 1022;
 pub const RPMTAG_FILESIZES: u32 = 1028;

--- a/crates/livraison/src/rpm/cpio.rs
+++ b/crates/livraison/src/rpm/cpio.rs
@@ -1,0 +1,133 @@
+//! A minimal writer for the `newc` (SVR4, no CRC) cpio format used as the RPM
+//! payload.
+//!
+//! Each entry is a fixed 110-byte ASCII-hex header, followed by the NUL
+//! terminated name and the file data, each padded to a 4-byte boundary. The
+//! archive ends with a special `TRAILER!!!` entry.
+
+use std::io::Read;
+
+use crate::{LivraisonResult, common::FileRef};
+
+const MAGIC: &[u8] = b"070701";
+
+pub struct CpioBuilder {
+    out: Vec<u8>,
+    /// Monotonic inode counter; values only need to be unique within the archive.
+    ino: u32,
+}
+
+impl Default for CpioBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CpioBuilder {
+    pub fn new() -> Self {
+        CpioBuilder {
+            out: Vec::new(),
+            ino: 1,
+        }
+    }
+
+    /// Add a regular file. `path` is the archive path, conventionally prefixed
+    /// with `./` (e.g. `./usr/local/bin/foo`).
+    pub fn add_file(
+        &mut self,
+        path: &str,
+        mode: u32,
+        mtime: u32,
+        source: &FileRef,
+    ) -> LivraisonResult<()> {
+        let mut data = Vec::new();
+        source.open()?.read_to_end(&mut data)?;
+        self.write_entry(path, mode, mtime, 1, &data);
+        self.ino += 1;
+        Ok(())
+    }
+
+    /// Finish the archive, appending the trailer, and return the bytes.
+    pub fn finish(mut self) -> Vec<u8> {
+        self.write_entry("TRAILER!!!", 0, 0, 1, &[]);
+        self.out
+    }
+
+    fn write_entry(&mut self, name: &str, mode: u32, mtime: u32, nlink: u32, data: &[u8]) {
+        let name_bytes = name.as_bytes();
+        let namesize = name_bytes.len() as u32 + 1; // include trailing NUL
+
+        self.out.extend_from_slice(MAGIC);
+        self.write_hex(self.ino);
+        self.write_hex(mode);
+        self.write_hex(0); // uid
+        self.write_hex(0); // gid
+        self.write_hex(nlink);
+        self.write_hex(mtime);
+        self.write_hex(data.len() as u32);
+        self.write_hex(0); // devmajor
+        self.write_hex(0); // devminor
+        self.write_hex(0); // rdevmajor
+        self.write_hex(0); // rdevminor
+        self.write_hex(namesize);
+        self.write_hex(0); // check
+
+        self.out.extend_from_slice(name_bytes);
+        self.out.push(0);
+        // The name field (starting after the 110-byte header) is padded so the
+        // file data begins on a 4-byte boundary.
+        self.pad_to_4();
+
+        self.out.extend_from_slice(data);
+        self.pad_to_4();
+    }
+
+    fn write_hex(&mut self, value: u32) {
+        // newc fields are 8 ASCII hex digits, zero padded, uppercase.
+        let s = format!("{value:08X}");
+        self.out.extend_from_slice(s.as_bytes());
+    }
+
+    fn pad_to_4(&mut self) {
+        while !self.out.len().is_multiple_of(4) {
+            self.out.push(0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_starts_with_magic() {
+        let builder = CpioBuilder::new();
+        let bytes = builder.finish();
+        assert_eq!(&bytes[0..6], MAGIC);
+    }
+
+    #[test]
+    fn trailer_is_present() {
+        let bytes = CpioBuilder::new().finish();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(text.contains("TRAILER!!!"));
+    }
+
+    #[test]
+    fn file_entry_is_4_byte_aligned() {
+        let mut builder = CpioBuilder::new();
+        builder
+            .add_file(
+                "./usr/local/bin/foo",
+                0o100755,
+                0,
+                &FileRef::from_text("hello world"),
+            )
+            .unwrap();
+        let bytes = builder.finish();
+        assert!(bytes.len().is_multiple_of(4));
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(text.contains("./usr/local/bin/foo"));
+        assert!(text.contains("hello world"));
+    }
+}

--- a/crates/livraison/src/rpm/header.rs
+++ b/crates/livraison/src/rpm/header.rs
@@ -1,0 +1,294 @@
+//! Serialization of an RPM *header* structure.
+//!
+//! A header is a self-describing collection of tagged records. It is used both
+//! for the signature section and for the main (immutable) metadata section of an
+//! RPM package. On disk a header is laid out as:
+//!
+//! ```text
+//! magic (3) | version (1) | reserved (4) | nentries (4) | store_size (4)
+//! nentries * index-entry (16 bytes each: tag, type, offset, count)
+//! data store (store_size bytes)
+//! ```
+//!
+//! Only serialization is implemented; livraison never needs to parse RPMs.
+
+use std::io::Write;
+
+use crate::LivraisonResult;
+
+use super::constants::{HEADER_MAGIC, INDEX_ENTRY_SIZE};
+
+/// The value/type pair stored by a single [`Entry`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypedData {
+    Int16(Vec<u16>),
+    Int32(Vec<u32>),
+    Str(String),
+    StringArray(Vec<String>),
+    Bin(Vec<u8>),
+}
+
+impl TypedData {
+    /// The RPM type identifier used in the index entry.
+    fn type_id(&self) -> u32 {
+        match self {
+            TypedData::Int16(_) => 3,
+            TypedData::Int32(_) => 4,
+            TypedData::Str(_) => 6,
+            TypedData::Bin(_) => 7,
+            TypedData::StringArray(_) => 8,
+        }
+    }
+
+    /// The number of items pointed to by the index entry.
+    fn count(&self) -> u32 {
+        match self {
+            TypedData::Int16(v) => v.len() as u32,
+            TypedData::Int32(v) => v.len() as u32,
+            TypedData::Str(_) => 1,
+            TypedData::Bin(v) => v.len() as u32,
+            TypedData::StringArray(v) => v.len() as u32,
+        }
+    }
+
+    /// Append the data to the store, inserting any leading padding required to
+    /// satisfy this type's alignment. Returns the number of padding bytes added.
+    fn append(&self, store: &mut Vec<u8>) -> u32 {
+        match self {
+            TypedData::Int16(v) => {
+                let pad = align(store, 2);
+                for item in v {
+                    store.extend_from_slice(&item.to_be_bytes());
+                }
+                pad
+            }
+            TypedData::Int32(v) => {
+                let pad = align(store, 4);
+                for item in v {
+                    store.extend_from_slice(&item.to_be_bytes());
+                }
+                pad
+            }
+            TypedData::Str(s) => {
+                store.extend_from_slice(s.as_bytes());
+                store.push(0);
+                0
+            }
+            TypedData::Bin(b) => {
+                store.extend_from_slice(b);
+                0
+            }
+            TypedData::StringArray(v) => {
+                for s in v {
+                    store.extend_from_slice(s.as_bytes());
+                    store.push(0);
+                }
+                0
+            }
+        }
+    }
+}
+
+/// Pad `store` with zero bytes until its length is a multiple of `alignment`.
+/// Returns the number of padding bytes added.
+fn align(store: &mut Vec<u8>, alignment: usize) -> u32 {
+    let mut pad = 0;
+    while !store.len().is_multiple_of(alignment) {
+        store.push(0);
+        pad += 1;
+    }
+    pad
+}
+
+/// A single tagged record within a header.
+#[derive(Debug, Clone)]
+pub struct Entry {
+    pub tag: u32,
+    pub data: TypedData,
+}
+
+impl Entry {
+    pub fn new(tag: u32, data: TypedData) -> Self {
+        Entry { tag, data }
+    }
+}
+
+/// Write a single 16-byte index entry (tag, type, offset, count).
+fn write_index_entry(out: &mut Vec<u8>, tag: u32, type_id: u32, offset: i32, count: u32) {
+    out.extend_from_slice(&tag.to_be_bytes());
+    out.extend_from_slice(&type_id.to_be_bytes());
+    out.extend_from_slice(&offset.to_be_bytes());
+    out.extend_from_slice(&count.to_be_bytes());
+}
+
+/// Serialize a set of records into a full header, wrapped in the given region
+/// tag (`RPMTAG_HEADERIMMUTABLE` for the main header, `RPMTAG_HEADERSIGNATURES`
+/// for the signature header).
+///
+/// Entries are sorted by tag, the region trailer is computed, and the whole
+/// structure is written to `out`. Returns the number of bytes written.
+pub fn write_header<W: Write>(
+    out: &mut W,
+    mut records: Vec<Entry>,
+    region_tag: u32,
+) -> LivraisonResult<usize> {
+    records.sort_by_key(|e| e.tag);
+
+    // Build the data store and the index entries for the actual records.
+    let mut store: Vec<u8> = Vec::new();
+    let mut index: Vec<u8> = Vec::new();
+    // The region tag is always the first index entry, so actual entries start
+    // at offset INDEX_ENTRY_SIZE within the index section. Reserve its slot.
+    let mut region_index: Vec<u8> = Vec::new();
+
+    for record in &records {
+        let offset_before = store.len() as i32;
+        let pad = record.data.append(&mut store) as i32;
+        let offset = offset_before + pad;
+        write_index_entry(
+            &mut index,
+            record.tag,
+            record.data.type_id(),
+            offset,
+            record.data.count(),
+        );
+    }
+
+    // The region trailer is a 16-byte index entry stored in the data store. Its
+    // offset points backwards over every index entry (region + actual records).
+    let record_count = records.len() as i32;
+    let trailer_offset = -((record_count + 1) * INDEX_ENTRY_SIZE);
+    let mut trailer: Vec<u8> = Vec::new();
+    write_index_entry(&mut trailer, region_tag, 7, trailer_offset, INDEX_ENTRY_SIZE as u32);
+
+    // The region index entry itself points at the trailer we are about to append.
+    let region_data_offset = store.len() as i32;
+    write_index_entry(
+        &mut region_index,
+        region_tag,
+        7,
+        region_data_offset,
+        INDEX_ENTRY_SIZE as u32,
+    );
+    store.extend_from_slice(&trailer);
+
+    let num_entries = (records.len() + 1) as u32;
+    let store_size = store.len() as u32;
+
+    let mut buf: Vec<u8> = Vec::new();
+    buf.extend_from_slice(&HEADER_MAGIC);
+    buf.push(1); // version
+    buf.extend_from_slice(&[0; 4]); // reserved
+    buf.extend_from_slice(&num_entries.to_be_bytes());
+    buf.extend_from_slice(&store_size.to_be_bytes());
+    buf.extend_from_slice(&region_index);
+    buf.extend_from_slice(&index);
+    buf.extend_from_slice(&store);
+
+    out.write_all(&buf)?;
+    Ok(buf.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpm::constants::{RPMTAG_HEADERIMMUTABLE, RPMTAG_NAME, RPMTAG_VERSION};
+
+    fn parse_u32(bytes: &[u8], at: usize) -> u32 {
+        u32::from_be_bytes(bytes[at..at + 4].try_into().unwrap())
+    }
+
+    #[test]
+    fn writes_magic_and_counts() {
+        let mut out = Vec::new();
+        write_header(
+            &mut out,
+            vec![
+                Entry::new(RPMTAG_VERSION, TypedData::Str("1.0".to_string())),
+                Entry::new(RPMTAG_NAME, TypedData::Str("test".to_string())),
+            ],
+            RPMTAG_HEADERIMMUTABLE,
+        )
+        .unwrap();
+
+        assert_eq!(&out[0..3], &HEADER_MAGIC);
+        assert_eq!(out[3], 1);
+        // num_entries = 2 records + 1 region tag
+        assert_eq!(parse_u32(&out, 8), 3);
+    }
+
+    #[test]
+    fn sorts_entries_by_tag_after_region() {
+        let mut out = Vec::new();
+        write_header(
+            &mut out,
+            vec![
+                Entry::new(RPMTAG_VERSION, TypedData::Str("1.0".to_string())),
+                Entry::new(RPMTAG_NAME, TypedData::Str("test".to_string())),
+            ],
+            RPMTAG_HEADERIMMUTABLE,
+        )
+        .unwrap();
+
+        // Index section starts at byte 16. First entry is the region tag.
+        let first_tag = parse_u32(&out, 16);
+        assert_eq!(first_tag, RPMTAG_HEADERIMMUTABLE);
+        // Next two entries must be sorted: NAME (1000) before VERSION (1001).
+        assert_eq!(parse_u32(&out, 16 + 16), RPMTAG_NAME);
+        assert_eq!(parse_u32(&out, 16 + 32), RPMTAG_VERSION);
+    }
+
+    #[test]
+    fn region_trailer_offset_points_back_over_all_entries() {
+        let mut out = Vec::new();
+        write_header(
+            &mut out,
+            vec![Entry::new(RPMTAG_NAME, TypedData::Str("test".to_string()))],
+            RPMTAG_HEADERIMMUTABLE,
+        )
+        .unwrap();
+
+        let num_entries = parse_u32(&out, 8);
+        let store_size = parse_u32(&out, 12) as usize;
+        let store_start = 16 + (num_entries as usize) * 16;
+        let store = &out[store_start..store_start + store_size];
+        // The trailer is the last 16 bytes of the store.
+        let trailer = &store[store.len() - 16..];
+        let offset = i32::from_be_bytes(trailer[8..12].try_into().unwrap());
+        // 2 entries total (region + NAME) => -(2 * 16)
+        assert_eq!(offset, -(2 * INDEX_ENTRY_SIZE));
+    }
+
+    #[test]
+    fn int32_data_is_4_byte_aligned() {
+        let mut out = Vec::new();
+        // A short string (odd length incl. NUL) followed by an int32 forces padding.
+        write_header(
+            &mut out,
+            vec![
+                Entry::new(1000, TypedData::Str("ab".to_string())),
+                Entry::new(1001, TypedData::Int32(vec![0x0a0b0c0d])),
+            ],
+            RPMTAG_HEADERIMMUTABLE,
+        )
+        .unwrap();
+
+        let num_entries = parse_u32(&out, 8);
+        let store_start = 16 + (num_entries as usize) * 16;
+        // "ab\0" occupies 3 bytes; int32 must be padded to offset 4.
+        // Find the int32 entry (tag 1001) and read its offset.
+        let mut int_offset = None;
+        for i in 0..num_entries as usize {
+            let base = 16 + i * 16;
+            if parse_u32(&out, base) == 1001 {
+                int_offset = Some(i32::from_be_bytes(
+                    out[base + 8..base + 12].try_into().unwrap(),
+                ));
+            }
+        }
+        let int_offset = int_offset.unwrap();
+        assert_eq!(int_offset % 4, 0);
+        let abs = store_start + int_offset as usize;
+        assert_eq!(&out[abs..abs + 4], &[0x0a, 0x0b, 0x0c, 0x0d]);
+    }
+}

--- a/crates/livraison/src/rpm/lead.rs
+++ b/crates/livraison/src/rpm/lead.rs
@@ -1,0 +1,66 @@
+//! The 96-byte RPM *lead* section.
+//!
+//! The lead is a legacy structure. Modern RPM tooling only uses its magic bytes
+//! to recognise a file as an RPM; the remaining fields are written with the
+//! conventional fixed values.
+
+use std::io::Write;
+
+use crate::LivraisonResult;
+
+use super::constants::RPM_MAGIC;
+
+/// Write the 96-byte lead for a binary package named `name`.
+pub fn write_lead<W: Write>(out: &mut W, name: &str) -> LivraisonResult<()> {
+    let mut buf: Vec<u8> = Vec::with_capacity(96);
+    buf.extend_from_slice(&RPM_MAGIC);
+    buf.push(3); // major version
+    buf.push(0); // minor version
+    buf.extend_from_slice(&0u16.to_be_bytes()); // type: 0 = binary
+    buf.extend_from_slice(&0u16.to_be_bytes()); // archnum
+
+    // name, 66 bytes, NUL padded, always NUL terminated.
+    let mut name_field = [0u8; 66];
+    let bytes = name.as_bytes();
+    let len = bytes.len().min(65);
+    name_field[..len].copy_from_slice(&bytes[..len]);
+    buf.extend_from_slice(&name_field);
+
+    buf.extend_from_slice(&1u16.to_be_bytes()); // osnum: 1 = Linux
+    buf.extend_from_slice(&5u16.to_be_bytes()); // signature type: 5 = header-style
+    buf.extend_from_slice(&[0u8; 16]); // reserved
+
+    out.write_all(&buf)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lead_is_96_bytes_with_magic() {
+        let mut out = Vec::new();
+        write_lead(&mut out, "test").unwrap();
+        assert_eq!(out.len(), 96);
+        assert_eq!(&out[0..4], &RPM_MAGIC);
+        assert_eq!(out[4], 3);
+    }
+
+    #[test]
+    fn name_is_written_and_nul_terminated() {
+        let mut out = Vec::new();
+        write_lead(&mut out, "hello").unwrap();
+        assert_eq!(&out[10..15], b"hello");
+        assert_eq!(out[15], 0);
+    }
+
+    #[test]
+    fn overlong_name_is_truncated_and_terminated() {
+        let long = "a".repeat(100);
+        let mut out = Vec::new();
+        write_lead(&mut out, &long).unwrap();
+        // 66-byte field, last byte must remain the NUL terminator.
+        assert_eq!(out[10 + 65], 0);
+    }
+}

--- a/crates/livraison/src/rpm/livraison_packer.rs
+++ b/crates/livraison/src/rpm/livraison_packer.rs
@@ -1,0 +1,75 @@
+use std::fs;
+
+use crate::{
+    LivraisonResult,
+    actions::pack::{CommonOptions, LivraisonPacker},
+    rpm::{
+        metadata::{RpmMetadata, User},
+        package::{DataFile, RpmPackage},
+    },
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct RpmLivraisonPacker {}
+
+impl LivraisonPacker for RpmLivraisonPacker {
+    fn pack(&self, options: CommonOptions) -> LivraisonResult<()> {
+        let description = options
+            .description
+            .clone()
+            .unwrap_or_else(|| "No description.".to_string());
+
+        let metadata = RpmMetadata {
+            name: options.name.clone(),
+            version: options.version.unwrap_or_else(|| "1.0.0".to_string()),
+            release: "1".to_string(),
+            // RPM requires a non-empty summary; fall back to the first line of
+            // the description.
+            summary: description.lines().next().unwrap_or("").to_string(),
+            description,
+            license: "Unknown".to_string(),
+            arch: "noarch".to_string(),
+            packager: match options.author {
+                Some(author) => User {
+                    name: author.name,
+                    email: author.email,
+                },
+                None => User::default(),
+            },
+        };
+
+        let files = options
+            .bin_files
+            .iter()
+            .map(|file| {
+                let dest = format!("/usr/local/bin/{}", file.file_name());
+                DataFile::new(dest, file.clone().with_mode(0o100755))
+            })
+            .collect::<Vec<DataFile>>();
+
+        let pkg = RpmPackage {
+            metadata: metadata.clone(),
+            files,
+        };
+
+        let out_file = options.out.join(&options.name).with_extension("rpm");
+        fs::create_dir_all(&options.out)?;
+
+        let file = fs::File::create(&out_file)?;
+        pkg.write(file)?;
+
+        println!("Created RPM package at: {}", out_file.to_string_lossy());
+        println!("  Name: {}", metadata.name);
+        println!("  Version: {}-{}", metadata.version, metadata.release);
+        println!("  Arch: {}", metadata.arch);
+        println!("Included files:");
+        if pkg.files.is_empty() {
+            println!("  No files included.");
+        } else {
+            for file in &pkg.files {
+                println!("  {}", file.get_dest());
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/livraison/src/rpm/metadata.rs
+++ b/crates/livraison/src/rpm/metadata.rs
@@ -1,0 +1,78 @@
+//! Package metadata for an RPM, analogous to the deb `Control`.
+
+/// A package author / packager.
+#[derive(Default, Debug, Clone)]
+pub struct User {
+    pub name: String,
+    pub email: String,
+}
+
+impl User {
+    /// Format as `Name <email>`, or just the name when no email is set.
+    pub fn format(&self) -> String {
+        if self.email.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{} <{}>", self.name, self.email)
+        }
+    }
+}
+
+/// Metadata describing an RPM package. Feeds the main header tags.
+#[derive(Debug, Clone)]
+pub struct RpmMetadata {
+    /// Package name.
+    pub name: String,
+    /// Upstream version (no dashes allowed by RPM).
+    pub version: String,
+    /// Package release / revision.
+    pub release: String,
+    /// One-line summary.
+    pub summary: String,
+    /// Long description.
+    pub description: String,
+    /// License identifier.
+    pub license: String,
+    /// Target architecture (e.g. `noarch`, `x86_64`).
+    pub arch: String,
+    /// Packager.
+    pub packager: User,
+}
+
+impl Default for RpmMetadata {
+    fn default() -> Self {
+        RpmMetadata {
+            name: String::new(),
+            version: "1.0.0".to_string(),
+            release: "1".to_string(),
+            summary: String::new(),
+            description: String::new(),
+            license: "Unknown".to_string(),
+            arch: "noarch".to_string(),
+            packager: User::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_format_with_email() {
+        let user = User {
+            name: "John Doe".to_string(),
+            email: "john@example.com".to_string(),
+        };
+        assert_eq!(user.format(), "John Doe <john@example.com>");
+    }
+
+    #[test]
+    fn user_format_without_email() {
+        let user = User {
+            name: "John Doe".to_string(),
+            email: String::new(),
+        };
+        assert_eq!(user.format(), "John Doe");
+    }
+}

--- a/crates/livraison/src/rpm/mod.rs
+++ b/crates/livraison/src/rpm/mod.rs
@@ -1,0 +1,10 @@
+pub mod constants;
+pub mod cpio;
+pub mod header;
+pub mod lead;
+pub mod metadata;
+pub mod package;
+
+mod livraison_packer;
+
+pub use livraison_packer::RpmLivraisonPacker;

--- a/crates/livraison/src/rpm/package.rs
+++ b/crates/livraison/src/rpm/package.rs
@@ -153,6 +153,15 @@ impl RpmPackage {
             ),
         ];
 
+        // The packager (author) is optional in RPM; only emit it when set, so we
+        // don't record an empty string. This mirrors the deb `Maintainer` field.
+        if !self.metadata.packager.name.is_empty() {
+            records.push(Entry::new(
+                RPMTAG_PACKAGER,
+                TypedData::Str(self.metadata.packager.format()),
+            ));
+        }
+
         if !self.files.is_empty() {
             records.push(Entry::new(RPMTAG_BASENAMES, TypedData::StringArray(basenames)));
             records.push(Entry::new(RPMTAG_DIRNAMES, TypedData::StringArray(dirnames)));

--- a/crates/livraison/src/rpm/package.rs
+++ b/crates/livraison/src/rpm/package.rs
@@ -4,7 +4,6 @@
 use std::io::Write;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use md5::Md5;
 use sha2::{Digest, Sha256};
 
 use crate::{LivraisonResult, common::FileRef, utils::compression::gzip};
@@ -119,6 +118,12 @@ impl RpmPackage {
 
         let payload = gzip(&cpio.finish())?;
 
+        // SHA-256 of the compressed payload, recorded so `rpm -K` can verify
+        // payload integrity (the modern replacement for the legacy SIGMD5).
+        let mut payload_hasher = Sha256::new();
+        payload_hasher.update(&payload);
+        let payload_sha256 = hex(&payload_hasher.finalize());
+
         // --- Build the main (immutable) header. ---
         let mut records = vec![
             Entry::new(RPMTAG_NAME, TypedData::Str(self.metadata.name.clone())),
@@ -138,6 +143,14 @@ impl RpmPackage {
             Entry::new(RPMTAG_PAYLOADCOMPRESSOR, TypedData::Str("gzip".to_string())),
             Entry::new(RPMTAG_PAYLOADFLAGS, TypedData::Str("9".to_string())),
             Entry::new(RPMTAG_ENCODING, TypedData::Str("utf-8".to_string())),
+            Entry::new(
+                RPMTAG_PAYLOADDIGEST,
+                TypedData::StringArray(vec![payload_sha256]),
+            ),
+            Entry::new(
+                RPMTAG_PAYLOADDIGESTALGO,
+                TypedData::Int32(vec![RPM_DIGEST_ALGO_SHA256]),
+            ),
         ];
 
         if !self.files.is_empty() {
@@ -169,21 +182,15 @@ impl RpmPackage {
         let mut header_bytes = Vec::new();
         write_header(&mut header_bytes, records, RPMTAG_HEADERIMMUTABLE)?;
 
-        // --- Build the signature header over the main header + payload. ---
+        // --- Build the signature header over the main header. ---
         let mut sha = Sha256::new();
         sha.update(&header_bytes);
         let header_sha256 = hex(&sha.finalize());
-
-        let mut md5 = Md5::new();
-        md5.update(&header_bytes);
-        md5.update(&payload);
-        let md5_digest = md5.finalize().to_vec();
 
         let sig_size = (header_bytes.len() + payload.len()) as u32;
         let sig_records = vec![
             Entry::new(RPMSIGTAG_SIZE, TypedData::Int32(vec![sig_size])),
             Entry::new(RPMSIGTAG_SHA256, TypedData::Str(header_sha256)),
-            Entry::new(RPMSIGTAG_MD5, TypedData::Bin(md5_digest)),
         ];
         let mut sig_bytes = Vec::new();
         write_header(&mut sig_bytes, sig_records, RPMTAG_HEADERSIGNATURES)?;

--- a/crates/livraison/src/rpm/package.rs
+++ b/crates/livraison/src/rpm/package.rs
@@ -1,0 +1,252 @@
+//! Assembly of a complete `.rpm` file: lead + signature header + main header +
+//! gzip-compressed cpio payload.
+
+use std::io::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use md5::Md5;
+use sha2::{Digest, Sha256};
+
+use crate::{LivraisonResult, common::FileRef, utils::compression::gzip};
+
+use super::{
+    constants::*,
+    cpio::CpioBuilder,
+    header::{Entry, TypedData, write_header},
+    lead::write_lead,
+    metadata::RpmMetadata,
+};
+
+/// A file to include in the package, installed at `dest` (an absolute path).
+#[derive(Debug, Clone)]
+pub struct DataFile {
+    dest: String,
+    source: FileRef,
+}
+
+impl DataFile {
+    pub fn new(dest: impl Into<String>, source: FileRef) -> Self {
+        DataFile {
+            dest: dest.into(),
+            source,
+        }
+    }
+
+    pub fn get_dest(&self) -> &str {
+        &self.dest
+    }
+}
+
+/// A full RPM package ready to be serialized.
+pub struct RpmPackage {
+    pub metadata: RpmMetadata,
+    pub files: Vec<DataFile>,
+}
+
+/// Split an absolute path into `(dirname, basename)` where `dirname` keeps its
+/// trailing slash, as required by RPM's `DIRNAMES`/`BASENAMES` tags.
+fn split_path(path: &str) -> (String, String) {
+    match path.rfind('/') {
+        Some(idx) => (path[..=idx].to_string(), path[idx + 1..].to_string()),
+        None => ("/".to_string(), path.to_string()),
+    }
+}
+
+/// Ensure a mode has the regular-file type bits set.
+fn as_file_mode(mode: u32) -> u32 {
+    if mode & 0o170000 == 0 {
+        mode | 0o100000
+    } else {
+        mode
+    }
+}
+
+impl RpmPackage {
+    pub fn write<W: Write>(&self, mut out: W) -> LivraisonResult<()> {
+        let mtime = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as u32)
+            .unwrap_or(0);
+
+        // --- Gather per-file metadata and build the cpio payload. ---
+        let mut basenames = Vec::new();
+        let mut dirnames: Vec<String> = Vec::new();
+        let mut dirindexes = Vec::new();
+        let mut filesizes = Vec::new();
+        let mut filemodes = Vec::new();
+        let mut filemtimes = Vec::new();
+        let mut filedigests = Vec::new();
+        let mut fileflags = Vec::new();
+        let mut fileusername = Vec::new();
+        let mut filegroupname = Vec::new();
+        let mut total_size: u32 = 0;
+
+        let mut cpio = CpioBuilder::new();
+
+        for file in &self.files {
+            let (dirname, basename) = split_path(&file.dest);
+            let dir_index = match dirnames.iter().position(|d| d == &dirname) {
+                Some(i) => i as u32,
+                None => {
+                    dirnames.push(dirname.clone());
+                    (dirnames.len() - 1) as u32
+                }
+            };
+
+            let mut data = Vec::new();
+            std::io::Read::read_to_end(&mut file.source.open()?, &mut data)?;
+            let size = data.len() as u32;
+            total_size += size;
+
+            let mut hasher = Sha256::new();
+            hasher.update(&data);
+            let digest = hex(&hasher.finalize());
+
+            let mode = as_file_mode(file.source.get_mode().unwrap_or(0o100755));
+
+            cpio.add_file(&format!(".{}", file.dest), mode, mtime, &file.source)?;
+
+            basenames.push(basename);
+            dirindexes.push(dir_index);
+            filesizes.push(size);
+            filemodes.push(mode as u16);
+            filemtimes.push(mtime);
+            filedigests.push(digest);
+            fileflags.push(0u32);
+            fileusername.push("root".to_string());
+            filegroupname.push("root".to_string());
+        }
+
+        let payload = gzip(&cpio.finish())?;
+
+        // --- Build the main (immutable) header. ---
+        let mut records = vec![
+            Entry::new(RPMTAG_NAME, TypedData::Str(self.metadata.name.clone())),
+            Entry::new(RPMTAG_VERSION, TypedData::Str(self.metadata.version.clone())),
+            Entry::new(RPMTAG_RELEASE, TypedData::Str(self.metadata.release.clone())),
+            Entry::new(RPMTAG_SUMMARY, TypedData::Str(self.metadata.summary.clone())),
+            Entry::new(
+                RPMTAG_DESCRIPTION,
+                TypedData::Str(self.metadata.description.clone()),
+            ),
+            Entry::new(RPMTAG_LICENSE, TypedData::Str(self.metadata.license.clone())),
+            Entry::new(RPMTAG_OS, TypedData::Str("linux".to_string())),
+            Entry::new(RPMTAG_ARCH, TypedData::Str(self.metadata.arch.clone())),
+            Entry::new(RPMTAG_SIZE, TypedData::Int32(vec![total_size])),
+            Entry::new(RPMTAG_RPMVERSION, TypedData::Str("4.0".to_string())),
+            Entry::new(RPMTAG_PAYLOADFORMAT, TypedData::Str("cpio".to_string())),
+            Entry::new(RPMTAG_PAYLOADCOMPRESSOR, TypedData::Str("gzip".to_string())),
+            Entry::new(RPMTAG_PAYLOADFLAGS, TypedData::Str("9".to_string())),
+            Entry::new(RPMTAG_ENCODING, TypedData::Str("utf-8".to_string())),
+        ];
+
+        if !self.files.is_empty() {
+            records.push(Entry::new(RPMTAG_BASENAMES, TypedData::StringArray(basenames)));
+            records.push(Entry::new(RPMTAG_DIRNAMES, TypedData::StringArray(dirnames)));
+            records.push(Entry::new(RPMTAG_DIRINDEXES, TypedData::Int32(dirindexes)));
+            records.push(Entry::new(RPMTAG_FILESIZES, TypedData::Int32(filesizes)));
+            records.push(Entry::new(RPMTAG_FILEMODES, TypedData::Int16(filemodes)));
+            records.push(Entry::new(RPMTAG_FILEMTIMES, TypedData::Int32(filemtimes)));
+            records.push(Entry::new(
+                RPMTAG_FILEDIGESTS,
+                TypedData::StringArray(filedigests),
+            ));
+            records.push(Entry::new(RPMTAG_FILEFLAGS, TypedData::Int32(fileflags)));
+            records.push(Entry::new(
+                RPMTAG_FILEUSERNAME,
+                TypedData::StringArray(fileusername),
+            ));
+            records.push(Entry::new(
+                RPMTAG_FILEGROUPNAME,
+                TypedData::StringArray(filegroupname),
+            ));
+            records.push(Entry::new(
+                RPMTAG_FILEDIGESTALGO,
+                TypedData::Int32(vec![RPM_DIGEST_ALGO_SHA256]),
+            ));
+        }
+
+        let mut header_bytes = Vec::new();
+        write_header(&mut header_bytes, records, RPMTAG_HEADERIMMUTABLE)?;
+
+        // --- Build the signature header over the main header + payload. ---
+        let mut sha = Sha256::new();
+        sha.update(&header_bytes);
+        let header_sha256 = hex(&sha.finalize());
+
+        let mut md5 = Md5::new();
+        md5.update(&header_bytes);
+        md5.update(&payload);
+        let md5_digest = md5.finalize().to_vec();
+
+        let sig_size = (header_bytes.len() + payload.len()) as u32;
+        let sig_records = vec![
+            Entry::new(RPMSIGTAG_SIZE, TypedData::Int32(vec![sig_size])),
+            Entry::new(RPMSIGTAG_SHA256, TypedData::Str(header_sha256)),
+            Entry::new(RPMSIGTAG_MD5, TypedData::Bin(md5_digest)),
+        ];
+        let mut sig_bytes = Vec::new();
+        write_header(&mut sig_bytes, sig_records, RPMTAG_HEADERSIGNATURES)?;
+        // The signature header is padded to an 8-byte boundary.
+        while !sig_bytes.len().is_multiple_of(8) {
+            sig_bytes.push(0);
+        }
+
+        // --- Emit the file. ---
+        write_lead(&mut out, &self.metadata.name)?;
+        out.write_all(&sig_bytes)?;
+        out.write_all(&header_bytes)?;
+        out.write_all(&payload)?;
+        Ok(())
+    }
+}
+
+/// Lowercase hex encoding.
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_path_keeps_trailing_slash() {
+        assert_eq!(
+            split_path("/usr/local/bin/foo"),
+            ("/usr/local/bin/".to_string(), "foo".to_string())
+        );
+    }
+
+    #[test]
+    fn as_file_mode_adds_regular_file_bits() {
+        assert_eq!(as_file_mode(0o755), 0o100755);
+        assert_eq!(as_file_mode(0o100644), 0o100644);
+    }
+
+    #[test]
+    fn hex_encodes_lowercase() {
+        assert_eq!(hex(&[0x00, 0xab, 0xff]), "00abff");
+    }
+
+    #[test]
+    fn writes_lead_magic() {
+        let pkg = RpmPackage {
+            metadata: RpmMetadata {
+                name: "test".to_string(),
+                ..Default::default()
+            },
+            files: vec![DataFile::new(
+                "/usr/local/bin/test",
+                FileRef::from_text("#!/bin/sh\n"),
+            )],
+        };
+        let mut out = Vec::new();
+        pkg.write(&mut out).unwrap();
+        assert_eq!(&out[0..4], &RPM_MAGIC);
+    }
+}

--- a/crates/livraison/tests/rpm_test.rs
+++ b/crates/livraison/tests/rpm_test.rs
@@ -66,6 +66,14 @@ fn check_rpm_retrieve_information() {
     assert_eq!(ask_rpm_for_field(target, "%{ARCH}"), metadata.arch);
     assert_eq!(ask_rpm_for_field(target, "%{LICENSE}"), metadata.license);
     assert_eq!(ask_rpm_for_field(target, "%{SUMMARY}"), metadata.summary);
+    assert_eq!(
+        ask_rpm_for_field(target, "%{DESCRIPTION}"),
+        metadata.description
+    );
+    assert_eq!(
+        ask_rpm_for_field(target, "%{PACKAGER}"),
+        format!("{} <{}>", metadata.packager.name, metadata.packager.email)
+    );
 }
 
 #[require_command("rpm")]

--- a/crates/livraison/tests/rpm_test.rs
+++ b/crates/livraison/tests/rpm_test.rs
@@ -112,12 +112,16 @@ fn check_rpm_header_digest_is_valid() {
     let target_path_buf = write_package("digest", &pkg);
     let target = target_path_buf.to_str().unwrap();
 
-    // `rpm -K` verifies the header SHA256 digest (among others). Without a GPG
+    // `rpm -K` verifies the header and payload SHA256 digests. Without a GPG
     // key it reports missing signatures but must not report a digest failure.
     let output = exec("rpm", &["-Kv", target]);
     let report = String::from_utf8(output.stdout).unwrap();
     assert!(
         report.contains("Header SHA256 digest: OK"),
+        "checksig report was: {report}"
+    );
+    assert!(
+        report.contains("Payload SHA256 digest: OK"),
         "checksig report was: {report}"
     );
 }

--- a/crates/livraison/tests/rpm_test.rs
+++ b/crates/livraison/tests/rpm_test.rs
@@ -1,0 +1,123 @@
+use std::{fs, sync::LazyLock};
+use test_macros::require_command;
+mod test_utils;
+use test_utils::{TestTempDir, exec};
+
+use livraison::{
+    common::FileRef,
+    rpm::{
+        metadata::{RpmMetadata, User},
+        package::{DataFile, RpmPackage},
+    },
+};
+
+pub static TESTDIR: LazyLock<TestTempDir> = LazyLock::new(|| {
+    let dir = TestTempDir::new("rpm");
+    dir.delete().expect("Worked");
+    dir
+});
+
+fn ask_rpm_for_field(target: &str, format: &str) -> String {
+    let output = exec("rpm", &["-qp", "--queryformat", format, target]);
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+fn mk_metadata() -> RpmMetadata {
+    RpmMetadata {
+        name: "test".to_string(),
+        version: "1.0.0".to_string(),
+        release: "1".to_string(),
+        summary: "Great test package".to_string(),
+        description: "Great test package\nWith nice description".to_string(),
+        license: "MIT".to_string(),
+        arch: "noarch".to_string(),
+        packager: User {
+            name: "John Smith".to_string(),
+            email: "john.smith@example.com".to_string(),
+        },
+    }
+}
+
+fn write_package(dir_name: &str, pkg: &RpmPackage) -> std::path::PathBuf {
+    let dir = TESTDIR.mkdir(dir_name).expect("Worked");
+    let target_path_buf = dir.join("test.rpm");
+    let file = fs::File::create(&target_path_buf).unwrap();
+    pkg.write(file).unwrap();
+    target_path_buf
+}
+
+#[require_command("rpm")]
+#[test]
+fn check_rpm_retrieve_information() {
+    let metadata = mk_metadata();
+    let pkg = RpmPackage {
+        metadata: metadata.clone(),
+        files: vec![DataFile::new(
+            "/usr/local/bin/test",
+            FileRef::from_text("#!/bin/sh\necho hello\n").with_mode(0o100755),
+        )],
+    };
+    let target_path_buf = write_package("query", &pkg);
+    let target = target_path_buf.to_str().unwrap();
+
+    assert_eq!(ask_rpm_for_field(target, "%{NAME}"), metadata.name);
+    assert_eq!(ask_rpm_for_field(target, "%{VERSION}"), metadata.version);
+    assert_eq!(ask_rpm_for_field(target, "%{RELEASE}"), metadata.release);
+    assert_eq!(ask_rpm_for_field(target, "%{ARCH}"), metadata.arch);
+    assert_eq!(ask_rpm_for_field(target, "%{LICENSE}"), metadata.license);
+    assert_eq!(ask_rpm_for_field(target, "%{SUMMARY}"), metadata.summary);
+}
+
+#[require_command("rpm")]
+#[test]
+fn check_rpm_lists_payload_files() {
+    let pkg = RpmPackage {
+        metadata: mk_metadata(),
+        files: vec![
+            DataFile::new(
+                "/usr/local/bin/test",
+                FileRef::from_text("#!/bin/sh\necho hello\n").with_mode(0o100755),
+            ),
+            DataFile::new(
+                "/usr/local/bin/other",
+                FileRef::from_text("#!/bin/sh\necho other\n").with_mode(0o100755),
+            ),
+        ],
+    };
+    let target_path_buf = write_package("files", &pkg);
+    let target = target_path_buf.to_str().unwrap();
+
+    let output = exec("rpm", &["-qlp", target]);
+    let listing = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        listing.contains("/usr/local/bin/test"),
+        "listing was: {listing}"
+    );
+    assert!(
+        listing.contains("/usr/local/bin/other"),
+        "listing was: {listing}"
+    );
+}
+
+#[require_command("rpm")]
+#[test]
+fn check_rpm_header_digest_is_valid() {
+    let pkg = RpmPackage {
+        metadata: mk_metadata(),
+        files: vec![DataFile::new(
+            "/usr/local/bin/test",
+            FileRef::from_text("#!/bin/sh\necho hello\n").with_mode(0o100755),
+        )],
+    };
+    let target_path_buf = write_package("digest", &pkg);
+    let target = target_path_buf.to_str().unwrap();
+
+    // `rpm -K` verifies the header SHA256 digest (among others). Without a GPG
+    // key it reports missing signatures but must not report a digest failure.
+    let output = exec("rpm", &["-Kv", target]);
+    let report = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        report.contains("Header SHA256 digest: OK"),
+        "checksig report was: {report}"
+    );
+}


### PR DESCRIPTION
Closes #33.

Adds a first-class RPM packer reachable via `livraison pack --target rpm ...`, at parity with the deb packer: package metadata (name/version/release/summary/description/license/arch/packager) plus installing the provided binaries to `/usr/local/bin`.

## Approach

Hand-rolls the RPM binary format from byte primitives, consistent with the deb (`ar`+`tar`+`gzip`) and msi packers — no heavy `rpm` crate dependency.

New `crates/livraison/src/rpm/` module mirroring `src/deb/`:

- **`constants.rs`** — RPM tag/type/magic values
- **`header.rs`** — core header serializer (tag/type/offset/count index + aligned data store + region trailer)
- **`lead.rs`** — 96-byte legacy lead
- **`cpio.rs`** — `newc` cpio payload writer
- **`metadata.rs`** — `RpmMetadata` (analog of deb `Control`)
- **`package.rs`** — assembles lead + signature header (SIZE + MD5 + SHA256) + main header + gzip(cpio); computes SHA-256 file digests
- **`livraison_packer.rs`** — `RpmLivraisonPacker` implementing `LivraisonPacker`

**Wiring:** `pub mod rpm;` in `lib.rs`; `"rpm" => …` in `get_packer`. Adds `sha2` + `md-5` (the only new deps) and installs `rpm` in the Linux CI leg so the `require_command`-gated tests run.

**Drive-by fix:** the CLI `--description` flag was accepted but never forwarded to `CommonOptions` (also affected deb) — now wired through.

## Testing

- 16 unit tests (header alignment/region trailer, cpio framing, lead, metadata, package) + 3 `#[require_command("rpm")]` integration tests in `tests/rpm_test.rs`.
- Verified a generated package with real `rpm`: `-qip`, `-qlp`, `--queryformat`, and `rpm2cpio | cpio` all correct; **`Header SHA256 digest: OK`**.
- Full `cargo test -p livraison` suite green; `cargo clippy` clean.

## Out of scope (future issues)

Dependencies (`Requires`), pre/post install scripts, conf files, GPG signing, and wiring RPM into `js/distribution` self-packaging.